### PR TITLE
Add hatch-jupyter-builder-feedstock

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 0dbd14a8aef6636764f88a8fd1fcc9a91921e5c50356e6aab251782f264ae960
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - hatchling >=1.0
+    - wheel
   run:
-    - python >=3.7
+    - python
     - hatchling >=1.0
 
 test:
@@ -38,7 +38,9 @@ test:
 about:
   home: https://pypi.org/project/hatch-jupyter-builder/
   summary: A hatch plugin to help build Jupyter packages
-  dev_url: https://github.com/blink0173/hatch-jupyter
+  description: A build hook plugin for Hatch that adds a build step for use with Jupyter packages.
+  dev_url: https://github.com/jupyterlab/hatch-jupyter-builder
+  doc_url: https://hatch-jupyter-builder.readthedocs.io/en/latest/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION
Hatchling is listed in the run section because we're testing a hatch plugin.