### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
-  number: 0
+  number: 1
 # Note s390x supressed because of conflicts installing test packages, and some
 # breakage around ffi/cffi loading
   skip: true  # [py<38 or s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hatch-jupyter-builder" %}
-{% set version = "0.8.3" %}
+{% set version = "0.9.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hatch_jupyter_builder-{{ version }}.tar.gz
-  sha256: 0dbd14a8aef6636764f88a8fd1fcc9a91921e5c50356e6aab251782f264ae960
+  sha256: 79278198d124c646b799c5e8dca8504aed9dcaaa88d071a09eb0b5c2009a58ad
 
 build:
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
-  number: 1
+  number: 0
 # Note s390x supressed because of conflicts installing test packages, and some
 # breakage around ffi/cffi loading
   skip: true  # [py<38 or s390x]
@@ -20,30 +20,26 @@ requirements:
   host:
     - pip
     - python
-    - hatchling >=1.5
+    - hatchling >=1.17
     - wheel
   run:
     - python
-    - hatchling >=1.5
-
+    - hatchling >=1.17
 
 test:
   source_files:
     - .
   imports:
     - hatch_jupyter_builder
-{% if python != "3.12" %}
   commands:
     - pip check
-# Note windows tests supressed because of problems with utils.run(shlex.split(cmd))
+    # Note windows tests supressed because of problems with utils.run(shlex.split(cmd))
     - python -m pytest -vv     # [not (win or s390x)]
   requires:
     - pip
-    - pytest               # [ not win]
-    - pytest-mock          # [ not win]
-    - tomli                # [ not win]
-    - cryptography =39.0.1 # [ not win]
-{% endif %}
+    - pytest
+    - pytest-mock
+    - tomli
 
 about:
   home: https://pypi.org/project/hatch-jupyter-builder/


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.9.1
https://github.com/jupyterlab/hatch-jupyter-builder/tree/v0.9.1